### PR TITLE
docs: Add contributing with project setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contribuindo
+
+Para contribuir com o site de comunidades do GURU BR, primeiro você precisa fazer o setup do projeto localmente.
+
+## Dependências
+
+Vamos começar instalando as dependências:
+
+```
+bundle install
+```
+
+Agora as dependências front-end:
+
+```
+yarn install
+```
+
+## Rodando
+
+O site foi construído utilizando [Jekyll](https://jekyllrb.com/docs/), para iniciar o servidor basta executar:
+
+```
+bundle exec jekyll server
+```
+
+## Fork
+
+Se você tem intenção de contribuir, lembre-se de realizar um fork do projeto para seu namespace no GitHub. Você pode também abrir uma issue com as informações da comunidade para adicionarmos.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-Repositorio do site de comunidades brasileiras Ruby
+# Comunidades Brasileiras Ruby
 
-Para contribuir você pode:
+Esse repositório tem o propósito de listar/conectar as comunidades brasileiras da linguagem de programação [Ruby](https://www.ruby-lang.org/pt/).
 
-- Criar um fork do projeto e abrir um PR adicionando apontando para staging com
-as informações da sua comunidade;
+## Contribuindo
 
-ps: A branch master é o site compilado e não deve ser usado como base de
-alteração, para isso use a branch staging!
+Leia o guia em [CONTRIBUTING.md](CONTRIBUTING.md).
 
-- Criar uma issue com essas informações para adicionarmos!
-
+## Código de Conduta
 
 Veja nosso codigo de conduta aqui:
 
-(Codigo de conduta do Ruby Brasil)[https://github.com/guru-br/code-of-conduct]
+[Código de Conduta do Ruby Brasil](https://github.com/guru-br/code-of-conduct)


### PR DESCRIPTION
## Motivation

Some people want to contribute with website but there are no details how to setup project locally.

## Proposed Solution

- [x] Add missing `CONTRIBUTING.md` following [contributing guidelines](https://en.wikipedia.org/wiki/Contributing_guidelines)
- [x] Remove details about `staging` branch in `README.md`
- [x] Add link to `CONTRIBUTING.md` in `README.md` 
- [x] Fix broken `code of conduct` in `README.md`