### PR TITLE
fix: remove scam site from rubyrio

### DIFF
--- a/collections/_groups/rubyonrio.html
+++ b/collections/_groups/rubyonrio.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 name: 'RubyOnRio'
-site_url: 'http://rubyonrio.com'
 telegram: 'rubyonrio'
 description: 'Grupo de usuários de Ruby do Rio de Janeiro'
 ---


### PR DESCRIPTION
The site https://rubyonrio.com/ render a not related to rubyonrio site